### PR TITLE
[FIX]: change "extension" to "program" in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
 
   - type: input
     attributes:
-      label: Extension version
+      label: Application version
       description: What version of the program are you using?
       placeholder: (eg v1.6.2)
     validations:
@@ -34,6 +34,7 @@ body:
         - Ubuntu
         - Arch
         - Other Linux-based OS
+        - Other Non Linux-based OS
     validations:
       required: true
 


### PR DESCRIPTION
changes "extension" to "program" in bug report template to actually reflect the program (was left over from when I copied the bug report from the extension Repo)