### PR TITLE
Manual login flow fix

### DIFF
--- a/src-tauri/src/auth/login.rs
+++ b/src-tauri/src/auth/login.rs
@@ -394,13 +394,6 @@ pub async fn create_login_window(app: tauri::AppHandle, url: String) -> Result<(
             }
         };
 
-        let full_url: Url = match Url::parse(&format!("{}/#?page=/welcome", parsed_url)) {
-            Ok(u) => u,
-            Err(e) => {
-                return Err(format!("Parsing error: {}", e));
-            }
-        };
-
         // Close any existing login windows first
         if let Some(existing_window) = app.get_webview_window("seqta_login") {
             let _ = existing_window.destroy();
@@ -413,7 +406,6 @@ pub async fn create_login_window(app: tauri::AppHandle, url: String) -> Result<(
                 .inner_size(900.0, 700.0)
                 .on_page_load({
                     // Clear session ID cookie, so that we can detect a login based on the creation of it.
-                    let parsed_url = parsed_url.clone();
                     move |window, _event| {
                         if let Ok(cookies) = window.cookies() {
                             for cookie in cookies {


### PR DESCRIPTION
The manual login webview window would always almost immediately close after opening. This was due to incorrect logic for checking if the user has yet logged in. This PR changes said logic to clear the current session cookie (one exists even prior to login), and await the creation of a new one (which only occurs upon login). This replaces the previous logic of awaiting a redirect to https://<seqta root>/#?page=/welcome, which was nonfunctional because SEQTA does not redirect upon login. The panel also opened to the same URL that it awaits, resulting in the almost immediate closing of the window.