### PR TITLE
Manual login flow navigation fixes

### DIFF
--- a/src-tauri/src/auth/login.rs
+++ b/src-tauri/src/auth/login.rs
@@ -457,7 +457,7 @@ pub async fn create_login_window(app: tauri::AppHandle, url: String) -> Result<(
         // Spawn the login window with unique ID
         // Start with about:blank to allow clearing data before loading the actual login page
         let webview_window =
-            WebviewWindowBuilder::new(&app, &window_id, WebviewUrl::App("about:blank".into()))
+            WebviewWindowBuilder::new(&app, &window_id, WebviewUrl::External("about:blank".parse().unwrap()))
                 .title("SEQTA Login")
                 .inner_size(900.0, 700.0)
                 .build()
@@ -470,9 +470,9 @@ pub async fn create_login_window(app: tauri::AppHandle, url: String) -> Result<(
         }
 
         // Navigate to the login URL
-        let url_string = parsed_url.to_string();
+        let url_clone = parsed_url.clone();
         webview_window
-            .eval(&format!("window.location.href = '{}'", url_string))
+            .navigate(url_clone)
             .map_err(|e| format!("Failed to navigate: {}", e))?;
 
         // Clone handles for async block


### PR DESCRIPTION
Prior to these changes, DesQTA would attempt to navigate to _**local**_ url "about:blank". Obviously, there is no "about:blank" file in the project, so it just loads nothing, and the JS runtime is not initialised, so the later navigation to the SEQTA login page fails. Also changed the navigation part to the proper rust-side API instead of JS injection.

May need testing on Windows/Mac/Android, as I only have Linux systems, in which DesQTA is already mostly non-functional, so I cannot check for any introduced issues. Though I doubt these changes will cause anything like that. (fingers crossed i havent messed up the git history this time :sweat_smile:)