### PR TITLE
fix: Incorrect logging logic for request errors

### DIFF
--- a/src/utils/netUtil.ts
+++ b/src/utils/netUtil.ts
@@ -92,7 +92,9 @@ export async function seqtaFetch(input: string, init?: SeqtaRequestInit): Promis
 
     return response;
   } catch (error) {
-    throw new Error(error instanceof Error ? error.message : 'Unknown fetch error');
+    throw new Error(
+      typeof error === 'string' ? error : ((error as Error)?.message ?? 'Unknown fetch error'),
+    );
   }
 }
 
@@ -104,7 +106,9 @@ export async function getRSS(url: string): Promise<any> {
     return response;
   } catch (error) {
     console.error('getRSS error:', error);
-    throw new Error(error instanceof Error ? error.message : 'Unknown fetch error');
+    throw new Error(
+      typeof error === 'string' ? error : ((error as Error)?.message ?? 'Unknown fetch error'),
+    );
   }
 }
 
@@ -115,7 +119,9 @@ export async function openURL(url: string): Promise<any> {
     });
   } catch (error) {
     console.error('openURL error:', error);
-    throw new Error(error instanceof Error ? error.message : 'Unknown fetch error');
+    throw new Error(
+      typeof error === 'string' ? error : ((error as Error)?.message ?? 'Unknown fetch error'),
+    );
   }
 }
 
@@ -128,6 +134,8 @@ export async function uploadSeqtaFile(fileName: string, filePath: string): Promi
     return response;
   } catch (error) {
     console.error('uploadSeqtaFile error:', error);
-    throw new Error(error instanceof Error ? error.message : 'Unknown upload error');
+    throw new Error(
+      typeof error === 'string' ? error : ((error as Error)?.message ?? 'Unknown fetch error'),
+    );
   }
 }


### PR DESCRIPTION
Fixes incorrect logic for logging fetch errors in netUtil.ts. Tauri's invoke throws a string, not an Error object.