### PR TITLE
Add OSSIGN signing

### DIFF
--- a/.github/workflows/windows-ossign-wait-signature.yml
+++ b/.github/workflows/windows-ossign-wait-signature.yml
@@ -1,0 +1,109 @@
+# Polls OSSign until signed assets are ready, then publishes a release on this repo.
+# Requires a GitHub Environment named "Signatures" with a wait timer (~20 minutes) so each poll is spaced out.
+# See https://github.com/ossign/example-workflow/blob/ossign/README.md
+
+name: OSSign wait and publish Windows release
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_id:
+        description: "Workflow ID returned by the OSSign dispatch step"
+        required: true
+        type: string
+      release_name:
+        description: "Release title (same as the dispatch workflow)"
+        required: true
+        type: string
+      attempt:
+        description: "Polling attempt number"
+        required: false
+        type: number
+        default: 1
+      max_attempts:
+        description: "Maximum polling attempts"
+        required: false
+        type: number
+        default: 100
+
+concurrency:
+  group: ossign-wait-${{ github.event.inputs.workflow_id }}
+  cancel-in-progress: false
+
+jobs:
+  wait-and-publish:
+    runs-on: ubuntu-latest
+    environment: Signatures
+
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - name: Check polling attempt limit
+        env:
+          ATTEMPT: ${{ github.event.inputs.attempt }}
+          MAX: ${{ github.event.inputs.max_attempts }}
+        run: |
+          if [ "$ATTEMPT" -gt "$MAX" ]; then
+            echo "::error::Maximum OSSign polling attempts reached (${MAX})."
+            exit 1
+          fi
+
+      - name: Check signing status with OSSign
+        id: check
+        uses: ossign/actions/workflow/dispatch@main
+        with:
+          username: ${{ secrets.OSSIGN_USER }}
+          token: ${{ secrets.OSSIGN_TOKEN }}
+          single_check: ${{ github.event.inputs.workflow_id }}
+
+      - name: Download signed artifacts from OSSign release
+        id: download
+        if: steps.check.outputs.signed_artifacts != ''
+        env:
+          ASSETS_JSON: ${{ steps.check.outputs.signed_artifacts }}
+        run: |
+          mkdir -p signed-dist
+          echo "$ASSETS_JSON" | jq -e '. | length > 0' >/dev/null
+          echo "$ASSETS_JSON" | jq -c '.[]' | while read -r row; do
+            url=$(echo "$row" | jq -r '.browser_download_url')
+            name=$(echo "$row" | jq -r '.name')
+            echo "Downloading: $name"
+            curl -fL --retry 3 --retry-delay 10 -o "signed-dist/${name}" "$url"
+          done
+          test -n "$(ls -A signed-dist)"
+
+      - name: Create GitHub prerelease with signed Windows assets
+        if: steps.check.outputs.signed_artifacts != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Windows signed - ${{ github.event.inputs.release_name }}
+          tag_name: windows-signed-${{ github.run_id }}
+          draft: false
+          prerelease: true
+          make_latest: false
+          body: |
+            Windows installers signed via [OSSign](https://github.com/OSSign).
+
+            Signing pipeline: [OSSign/BetterSEQTA-DesQTA](https://github.com/OSSign/BetterSEQTA-DesQTA).
+
+            OSSign workflow ID: `${{ github.event.inputs.workflow_id }}`
+          files: |
+            signed-dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Schedule another poll (signing not finished yet)
+        if: steps.check.outputs.signed_artifacts == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT=$(( ${{ github.event.inputs.attempt }} + 1 ))
+          echo "Signing not complete yet (attempt ${{ github.event.inputs.attempt }}); scheduling attempt ${NEXT}"
+          gh workflow run windows-ossign-wait-signature.yml \
+            --ref "${GITHUB_REF}" \
+            -f workflow_id="${{ github.event.inputs.workflow_id }}" \
+            -f release_name="${{ github.event.inputs.release_name }}" \
+            -f attempt="${NEXT}" \
+            -f max_attempts="${{ github.event.inputs.max_attempts }}"

--- a/.github/workflows/windows-signed-binaries.yml
+++ b/.github/workflows/windows-signed-binaries.yml
@@ -3,76 +3,81 @@ name: Build Signed Windows Binaries
 on:
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: "Git branch, tag, or commit to build"
-        required: false
-        default: "main"
-        type: string
-      review_window_confirmation:
+      acknowledge_review_window:
         description: "I understand this is usually reviewed between 08:00–23:00 CEST (17:30–08:30 ACDT)"
+        type: boolean
         required: true
         default: false
+      source_ref:
+        description: "Branch, tag, or commit to build"
+        required: true
+        default: "main"
+      release_name:
+        description: "Release title"
+        required: true
+      prerelease:
+        description: "Mark GitHub release as prerelease"
         type: boolean
+        required: false
+        default: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  build-signed-windows:
-    name: Build signed Windows artifacts
+  build-and-sign-windows:
     runs-on: windows-latest
-    environment: OSSign
+    env:
+      RUST_TARGET: x86_64-pc-windows-msvc
 
     steps:
-      - name: Verify review window confirmation
-        if: ${{ inputs.review_window_confirmation != true }}
+      - name: Validate OSSign review window acknowledgement
+        if: ${{ github.event.inputs.acknowledge_review_window != 'true' }}
         shell: pwsh
         run: |
-          Write-Error "Please check the confirmation box before starting this workflow."
-          exit 1
+          throw "You must acknowledge the OSSign review window (08:00-23:00 CEST / 17:30-08:30 ACDT) before running this workflow."
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ github.event.inputs.source_ref }}
           fetch-depth: 1
 
       - name: Install OSSign CLI
         uses: ossign/ossign@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          config: ${{ secrets.OSSIGN_CONFIG }}
           installOnly: true
 
-      - name: Inject OSSign sign command into Tauri config
+      - name: Configure Tauri Windows signing with OSSign
         shell: pwsh
+        env:
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
         run: |
-          $configPath = "src-tauri/tauri.conf.json"
-          $raw = Get-Content $configPath -Raw
-          $config = $raw | ConvertFrom-Json -Depth 100
-
-          if (-not $config.bundle.windows) {
-            $config.bundle | Add-Member -NotePropertyName windows -NotePropertyValue (@{})
-          }
-
-          $config.bundle.windows | Add-Member -NotePropertyName signCommand -NotePropertyValue "powershell -ExecutionPolicy Bypass -File sign.ps1 %1" -Force
-          ($config | ConvertTo-Json -Depth 100) | Set-Content $configPath
-
-      - name: Create signing script
-        shell: pwsh
-        run: |
+          $signScriptPath = "src-tauri/sign.ps1"
           @'
-          param(
-            [Parameter(Mandatory = $true)]
-            [string]$File
-          )
+          param([string]$FilePath)
+          if (-not $FilePath) {
+            throw "Missing file path argument."
+          }
+          $resolvedPath = (Resolve-Path $FilePath).Path
+          $tool = Get-ChildItem $env:RUNNER_TOOL_CACHE -Filter ossign.exe -Recurse | Select-Object -First 1
+          if (-not $tool) {
+            throw "Could not locate ossign.exe in RUNNER_TOOL_CACHE."
+          }
+          $type = if ($resolvedPath.ToLower().EndsWith(".msi")) { "msi" } else { "pecoff" }
+          & $tool.FullName -t $type -o $resolvedPath $resolvedPath
+          '@ | Set-Content -Path $signScriptPath -Encoding utf8
 
-          $ErrorActionPreference = "Stop"
-          $extension = [System.IO.Path]::GetExtension($File).ToLowerInvariant()
-          $signType = if ($extension -eq ".msi") { "msi" } else { "pecoff" }
-
-          Write-Host "Signing file '$File' as '$signType'"
-          ossign -t $signType -o "$File" "$File"
-          '@ | Set-Content src-tauri/sign.ps1
+          $configPath = "src-tauri/tauri.conf.json"
+          $json = Get-Content $configPath -Raw | ConvertFrom-Json
+          if (-not $json.bundle.windows) {
+            $json.bundle | Add-Member -NotePropertyName windows -NotePropertyValue ([PSCustomObject]@{}) -Force
+          }
+          $json.bundle.windows.signCommand = 'powershell -ExecutionPolicy Bypass -File sign.ps1 %1'
+          $json.plugins.updater.pubkey = $env:TAURI_SIGNING_PUBLIC_KEY
+          $json | ConvertTo-Json -Depth 100 | Set-Content -Path $configPath -Encoding utf8
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -88,7 +93,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ env.RUST_TARGET }}
 
       - name: Install dependencies
         run: pnpm install
@@ -97,16 +102,29 @@ jobs:
         run: pnpm tauri icon static/app-icon.svg
 
       - name: Build signed Windows binaries
+        shell: pwsh
         env:
           OSSIGN_CONFIG: ${{ secrets.OSSIGN_CONFIG }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: pnpm tauri build --target x86_64-pc-windows-msvc
+        run: pnpm tauri build --target $env:RUST_TARGET
 
-      - name: Upload signed Windows artifacts
+      - name: Upload signed build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: signed-windows-x86_64
+          name: windows-signed-x86_64
           path: |
-            src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**
-            src-tauri/target/x86_64-pc-windows-msvc/release/*.sig
+            src-tauri/target/${{ env.RUST_TARGET }}/release/bundle/**
+            src-tauri/target/${{ env.RUST_TARGET }}/release/*.sig
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.event.inputs.release_name }}
+          tag_name: windows-signed-${{ github.run_id }}
+          draft: false
+          prerelease: ${{ github.event.inputs.prerelease }}
+          body: |
+            Windows binaries signed with OSSign.
+            OSSign integration reference: https://github.com/BetterSEQTA/BetterSEQTA-DesQTA-ossign
+          files: |
+            src-tauri/target/${{ env.RUST_TARGET }}/release/bundle/**
+            src-tauri/target/${{ env.RUST_TARGET }}/release/*.sig

--- a/.github/workflows/windows-signed-binaries.yml
+++ b/.github/workflows/windows-signed-binaries.yml
@@ -1,126 +1,57 @@
-name: Build Signed Windows Binaries
+# Orchestrates OSSign remote signing per https://github.com/OSSign/template-repository/wiki/Your-OSSign-Workflow
+# Builds + signing run on the OSSign companion repo (BetterSEQTA-DesQTA); this workflow only dispatches and starts the wait loop.
+#
+# Repo secrets (repository-level): OSSIGN_USER, OSSIGN_TOKEN (from OSSign after approval).
+# Branch/tag built by OSSign matches the ref you select when starting this workflow ("Use workflow from").
+
+name: Windows signed binaries (OSSign dispatch)
 
 on:
   workflow_dispatch:
     inputs:
       acknowledge_review_window:
-        description: "I understand this is usually reviewed between 08:00–23:00 CEST (17:30–08:30 ACDT)"
+        description: "I understand signing is usually reviewed between 08:00–23:00 CEST (17:30–08:30 ACDT)"
         type: boolean
         required: true
         default: false
-      source_ref:
-        description: "Branch, tag, or commit to build"
-        required: true
-        default: "main"
       release_name:
-        description: "Release title"
+        description: "Title for the GitHub release published here after OSSign finishes"
         required: true
 
 permissions:
-  contents: write
+  contents: read
+  actions: write
 
 jobs:
-  build-and-sign-windows:
-    runs-on: windows-latest
-    env:
-      RUST_TARGET: x86_64-pc-windows-msvc
-
+  dispatch-to-ossign:
+    runs-on: ubuntu-latest
     steps:
       - name: Validate OSSign review window acknowledgement
         if: ${{ github.event.inputs.acknowledge_review_window != 'true' }}
-        shell: pwsh
         run: |
-          throw "You must acknowledge the OSSign review window (08:00-23:00 CEST / 17:30-08:30 ACDT) before running this workflow."
+          echo "::error::You must acknowledge the OSSign review window before running this workflow."
+          exit 1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch signing workflow on OSSign
+        id: dispatch
+        uses: ossign/actions/workflow/dispatch@main
         with:
-          ref: ${{ github.event.inputs.source_ref }}
-          fetch-depth: 1
+          username: ${{ secrets.OSSIGN_USER }}
+          token: ${{ secrets.OSSIGN_TOKEN }}
+          dispatch_only: true
 
-      - name: Install OSSign CLI
-        uses: ossign/ossign@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          config: ${{ secrets.OSSIGN_CONFIG }}
-          installOnly: true
-
-      - name: Configure Tauri Windows signing with OSSign
-        shell: pwsh
-        env:
-          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+      - name: Log OSSign workflow ID
         run: |
-          $signScriptPath = "src-tauri/sign.ps1"
-          @'
-          param([string]$FilePath)
-          if (-not $FilePath) {
-            throw "Missing file path argument."
-          }
-          $resolvedPath = (Resolve-Path $FilePath).Path
-          $tool = Get-ChildItem $env:RUNNER_TOOL_CACHE -Filter ossign.exe -Recurse | Select-Object -First 1
-          if (-not $tool) {
-            throw "Could not locate ossign.exe in RUNNER_TOOL_CACHE."
-          }
-          $type = if ($resolvedPath.ToLower().EndsWith(".msi")) { "msi" } else { "pecoff" }
-          & $tool.FullName -t $type -o $resolvedPath $resolvedPath
-          '@ | Set-Content -Path $signScriptPath -Encoding utf8
+          echo "OSSign workflow ID: ${{ steps.dispatch.outputs.workflow_id }}"
+          echo "Source ref sent to OSSign follows the branch/tag you selected above: ${GITHUB_REF}"
 
-          $configPath = "src-tauri/tauri.conf.json"
-          $json = Get-Content $configPath -Raw | ConvertFrom-Json
-          if (-not $json.bundle.windows) {
-            $json.bundle | Add-Member -NotePropertyName windows -NotePropertyValue ([PSCustomObject]@{}) -Force
-          }
-          $json.bundle.windows.signCommand = 'powershell -ExecutionPolicy Bypass -File sign.ps1 %1'
-          $json.plugins.updater.pubkey = $env:TAURI_SIGNING_PUBLIC_KEY
-          $json | ConvertTo-Json -Depth 100 | Set-Content -Path $configPath -Encoding utf8
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ env.RUST_TARGET }}
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Generate app icons
-        run: pnpm tauri icon static/app-icon.svg
-
-      - name: Build signed Windows binaries
-        shell: pwsh
+      - name: Start wait loop for signed artifacts
         env:
-          OSSIGN_CONFIG: ${{ secrets.OSSIGN_CONFIG }}
-        run: pnpm tauri build --target $env:RUST_TARGET
-
-      - name: Upload signed build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-signed-x86_64
-          path: |
-            src-tauri/target/${{ env.RUST_TARGET }}/release/bundle/**
-            src-tauri/target/${{ env.RUST_TARGET }}/release/*.sig
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Windows Signed Pre-release - ${{ github.event.inputs.release_name }}"
-          tag_name: prerelease-windows-signed-${{ github.run_id }}
-          draft: false
-          prerelease: true
-          make_latest: false
-          body: |
-            Windows binaries signed with OSSign.
-            OSSign integration reference: https://github.com/BetterSEQTA/BetterSEQTA-DesQTA-ossign
-          files: |
-            src-tauri/target/${{ env.RUST_TARGET }}/release/bundle/**
-            src-tauri/target/${{ env.RUST_TARGET }}/release/*.sig
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run windows-ossign-wait-signature.yml \
+            --ref "${GITHUB_REF}" \
+            -f workflow_id="${{ steps.dispatch.outputs.workflow_id }}" \
+            -f release_name="${{ github.event.inputs.release_name }}" \
+            -f attempt=1 \
+            -f max_attempts=100

--- a/.github/workflows/windows-signed-binaries.yml
+++ b/.github/workflows/windows-signed-binaries.yml
@@ -1,0 +1,112 @@
+name: Build Signed Windows Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Git branch, tag, or commit to build"
+        required: false
+        default: "main"
+        type: string
+      review_window_confirmation:
+        description: "I understand this is usually reviewed between 08:00–23:00 CEST (17:30–08:30 ACDT)"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build-signed-windows:
+    name: Build signed Windows artifacts
+    runs-on: windows-latest
+    environment: OSSign
+
+    steps:
+      - name: Verify review window confirmation
+        if: ${{ inputs.review_window_confirmation != true }}
+        shell: pwsh
+        run: |
+          Write-Error "Please check the confirmation box before starting this workflow."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+
+      - name: Install OSSign CLI
+        uses: ossign/ossign@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          installOnly: true
+
+      - name: Inject OSSign sign command into Tauri config
+        shell: pwsh
+        run: |
+          $configPath = "src-tauri/tauri.conf.json"
+          $raw = Get-Content $configPath -Raw
+          $config = $raw | ConvertFrom-Json -Depth 100
+
+          if (-not $config.bundle.windows) {
+            $config.bundle | Add-Member -NotePropertyName windows -NotePropertyValue (@{})
+          }
+
+          $config.bundle.windows | Add-Member -NotePropertyName signCommand -NotePropertyValue "powershell -ExecutionPolicy Bypass -File sign.ps1 %1" -Force
+          ($config | ConvertTo-Json -Depth 100) | Set-Content $configPath
+
+      - name: Create signing script
+        shell: pwsh
+        run: |
+          @'
+          param(
+            [Parameter(Mandatory = $true)]
+            [string]$File
+          )
+
+          $ErrorActionPreference = "Stop"
+          $extension = [System.IO.Path]::GetExtension($File).ToLowerInvariant()
+          $signType = if ($extension -eq ".msi") { "msi" } else { "pecoff" }
+
+          Write-Host "Signing file '$File' as '$signType'"
+          ossign -t $signType -o "$File" "$File"
+          '@ | Set-Content src-tauri/sign.ps1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate app icons
+        run: pnpm tauri icon static/app-icon.svg
+
+      - name: Build signed Windows binaries
+        env:
+          OSSIGN_CONFIG: ${{ secrets.OSSIGN_CONFIG }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build --target x86_64-pc-windows-msvc
+
+      - name: Upload signed Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-windows-x86_64
+          path: |
+            src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**
+            src-tauri/target/x86_64-pc-windows-msvc/release/*.sig

--- a/.github/workflows/windows-signed-binaries.yml
+++ b/.github/workflows/windows-signed-binaries.yml
@@ -15,11 +15,6 @@ on:
       release_name:
         description: "Release title"
         required: true
-      prerelease:
-        description: "Mark GitHub release as prerelease"
-        type: boolean
-        required: false
-        default: true
 
 permissions:
   contents: write
@@ -118,10 +113,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.event.inputs.release_name }}
-          tag_name: windows-signed-${{ github.run_id }}
+          name: "Windows Signed Pre-release - ${{ github.event.inputs.release_name }}"
+          tag_name: prerelease-windows-signed-${{ github.run_id }}
           draft: false
-          prerelease: ${{ github.event.inputs.prerelease }}
+          prerelease: true
+          make_latest: false
           body: |
             Windows binaries signed with OSSign.
             OSSign integration reference: https://github.com/BetterSEQTA/BetterSEQTA-DesQTA-ossign

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Weekly builds are available via GitHub Actions. You can download the latest buil
 Full Releases are available under the releases tab.  
 [Quick access link](https://github.com/BetterSEQTA/DesQTA/releases/latest)
 
+Proudly signed by [OSSIGN](https://github.com/OSSign/BetterSEQTA-DesQTA).
+
 
 ## Getting Started
 > [!IMPORTANT]  

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Welcome to the comprehensive documentation for DesQTA - a modern student managem
 ### 🔧 Development & Deployment
 
 - [Build Process & Deployment](./development/build-deployment.md) - Build system and deployment guide
-- [Windows OSSign Workflow Onboarding](./development/windows-ossign-workflow-onboarding.md) - Setup and run signed Windows binary builds
+- [Windows OSSign Workflow Onboarding](./development/windows-ossign-workflow-onboarding.md) - Enable dispatch, wait loop, secrets, and releases
 - [Logging System](./development/logging-system.md) - Comprehensive logging and debugging
 - [Logging Quick Reference](./development/logging-quick-reference.md) - Quick reference for logging APIs
 - [Future Roadmap](./development/future-roadmap.md) - Comprehensive development plan and roadmap

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Welcome to the comprehensive documentation for DesQTA - a modern student managem
 ### 🔧 Development & Deployment
 
 - [Build Process & Deployment](./development/build-deployment.md) - Build system and deployment guide
+- [Windows OSSign Workflow Onboarding](./development/windows-ossign-workflow-onboarding.md) - Setup and run signed Windows binary builds
 - [Logging System](./development/logging-system.md) - Comprehensive logging and debugging
 - [Logging Quick Reference](./development/logging-quick-reference.md) - Quick reference for logging APIs
 - [Future Roadmap](./development/future-roadmap.md) - Comprehensive development plan and roadmap

--- a/docs/development/build-deployment.md
+++ b/docs/development/build-deployment.md
@@ -490,6 +490,14 @@ src-tauri/gen/apple/build/
 
 ## 🔄 Continuous Integration & Deployment
 
+### Signed Windows Binaries (OSSign)
+
+DesQTA includes a dedicated manual workflow at `.github/workflows/windows-signed-binaries.yml` to build and sign Windows artifacts via OSSign.
+
+- Trigger: `workflow_dispatch`
+- Outputs: signed Windows bundle artifacts and `.sig` files
+- Release: creates a GitHub release tagged `windows-signed-<run_id>`
+
 ### GitHub Actions Workflow (`.github/workflows/build.yml`)
 
 ```yaml

--- a/docs/development/build-deployment.md
+++ b/docs/development/build-deployment.md
@@ -492,11 +492,14 @@ src-tauri/gen/apple/build/
 
 ### Signed Windows Binaries (OSSign)
 
-DesQTA includes a dedicated manual workflow at `.github/workflows/windows-signed-binaries.yml` to build and sign Windows artifacts via OSSign.
+Signing follows the [OSSign trigger workflow](https://github.com/OSSign/template-repository/wiki/Your-OSSign-Workflow#the-trigger-workflow): [`.github/workflows/windows-signed-binaries.yml`](../../.github/workflows/windows-signed-binaries.yml) dispatches the build/sign pipeline on OSSign’s companion repo ([`OSSign/BetterSEQTA-DesQTA`](https://github.com/OSSign/BetterSEQTA-DesQTA)); [`.github/workflows/windows-ossign-wait-signature.yml`](../../.github/workflows/windows-ossign-wait-signature.yml) polls until signed artifacts exist, then publishes a prerelease here.
 
-- Trigger: `workflow_dispatch`
-- Outputs: signed Windows bundle artifacts and `.sig` files
-- Release: creates a GitHub release tagged `windows-signed-<run_id>`
+- **Trigger:** manual `workflow_dispatch` on `windows-signed-binaries.yml` (pick the branch/tag to build via **Use workflow from**; that ref is what OSSign receives)
+- **Secrets:** `OSSIGN_USER` and `OSSIGN_TOKEN` (not `OSSIGN_CONFIG` in this repo’s workflows)
+- **Environment:** create a GitHub Environment named `Signatures` with a wait timer (~20 minutes) for the wait workflow, per [OSSign/example-workflow](https://github.com/ossign/example-workflow)
+- **Release:** prerelease tagged `windows-signed-<run_id>` on this repository
+
+Step-by-step onboarding (secrets, `Signatures` environment, triggers): [Windows OSSign Workflow Onboarding](./windows-ossign-workflow-onboarding.md).
 
 ### GitHub Actions Workflow (`.github/workflows/build.yml`)
 


### PR DESCRIPTION
# Windows OSSign Workflow Onboarding

This guide explains how to enable and use the OSSign-based GitHub Actions workflows in DesQTA. Signing follows the [OSSign trigger workflow](https://github.com/OSSign/template-repository/wiki/Your-OSSign-Workflow#the-trigger-workflow) and [example-workflow](https://github.com/ossign/example-workflow) pattern: **this repository dispatches** remote build/sign work to OSSign and **polls until signed installers are published**, then **creates a release here**.

Actual Windows builds and PE/COFF or MSI signing run on OSSign’s companion repository ([OSSign/BetterSEQTA-DesQTA](https://github.com/OSSign/BetterSEQTA-DesQTA)), not on `windows-latest` in DesQTA.

## What these workflows do

| Workflow file | Purpose |
|----------------|---------|
| [`.github/workflows/windows-signed-binaries.yml`](../../.github/workflows/windows-signed-binaries.yml) | Dispatches signing to OSSign (`ossign/actions/workflow/dispatch`), logs the OSSign workflow ID, then starts the wait workflow on the **same branch/tag** you selected (“Use workflow from”). |
| [`.github/workflows/windows-ossign-wait-signature.yml`](../../.github/workflows/windows-ossign-wait-signature.yml) | Uses the **`Signatures`** environment (with a wait timer) to poll OSSign until signed assets exist, downloads them, and publishes a **GitHub prerelease** on **BetterSEQTA/DesQTA** tagged `windows-signed-<run_id>`. |

Together they replace older setups that built on `windows-latest` here with `OSSIGN_CONFIG` and a generated `sign.ps1`.

## 1) Add required repository secrets

In GitHub: **Settings → Secrets and variables → Actions**, add:

| Secret | Purpose |
|--------|---------|
| **`OSSIGN_USER`** | OSSign username (provided after approval). |
| **`OSSIGN_TOKEN`** | OSSign token used by [`ossign/actions/workflow/dispatch`](https://github.com/ossign/actions/tree/main/workflow/dispatch). |

Notes:

- **`GITHUB_TOKEN`** is supplied automatically; the dispatch workflow needs **`actions: write`** so it can start the wait workflow via `gh workflow run`.
- Do **not** commit credentials. Repository or environment secrets only.
- Signing credentials such as **`OSSIGN_CONFIG`** live on OSSign’s side / companion repo workflows; **you do not use `OSSIGN_CONFIG` in DesQTA’s dispatch workflows** anymore.

Optional context:

- **`TAURI_SIGNING_PUBLIC_KEY`** and updater signing are handled where the **Tauri build runs** (typically the OSSign companion repo or local release tooling). DesQTA’s dispatch workflows do **not** rewrite `src-tauri/tauri.conf.json` at runtime.

## 2) Configure the `Signatures` environment

The wait workflow requires a GitHub **Environment** named **`Signatures`**:

1. **Settings → Environments → New environment** → name it **`Signatures`**.
2. Enable **Wait timer** and set it to about **20 minutes** (spacing between polls), as described in [OSSign/example-workflow README](https://github.com/ossign/example-workflow/blob/ossign/README.md).

Secrets **`OSSIGN_USER`** / **`OSSIGN_TOKEN`** stay at **repository** level (not only on the environment), matching OSSign’s docs.

## 3) Trigger the dispatch workflow

1. Open **Actions → Windows signed binaries (OSSign dispatch)** (workflow file `windows-signed-binaries.yml`).
2. Click **Run workflow**.
3. Choose **Use workflow from**: pick the **branch or tag** OSSign should build. That choice sets `GITHUB_REF`; OSSign receives that ref via their dispatch API (do not rely on a separate “commit” field in this workflow).
4. Fill inputs:
   - **`acknowledge_review_window`**: set to **`true`** so the run proceeds (signing is usually reviewed between **08:00–23:00 CEST** / **17:30–08:30 ACDT**).
   - **`release_name`**: human-readable title for the GitHub release created **after** OSSign finishes (shown on the prerelease published in this repo).

The dispatch step prints an **OSSign workflow ID** in the log; the wait workflow uses it automatically.

## 4) Verify successful signing

After OSSign completes and the wait workflow downloads assets:

- Find the **prerelease** on **BetterSEQTA/DesQTA** whose tag looks like **`windows-signed-<run_id>`** (`run_id` is from the **wait** workflow run unless you changed the tagging logic).
- Confirm attached files (e.g. `.exe`, `.msi`, and any `.sig` or bundle files OSSign publishes).
- Optionally download an installer and check **Digital Signatures** in Windows file properties.

If you need status outside GitHub, use the OSSign workflow ID from the dispatch job logs.

## 5) Common setup issues

| Symptom | What to check |
|--------|----------------|
| Dispatch fails immediately | **`OSSIGN_USER`** / **`OSSIGN_TOKEN`** missing, wrong, or expired. |
| Wait workflow fails: environment | Create **`Signatures`** and the **wait timer**; ensure the workflow name matches `windows-ossign-wait-signature.yml`. |
| “Maximum polling attempts reached” | Signing is slow or blocked; widen **`max_attempts`** in the workflow file or wait and re-dispatch after OSSign resolves it. |
| No release assets | Build/sign failed on **OSSign/BetterSEQTA-DesQTA**; inspect that repository’s Actions and OSSign approval. |
| Wrong code version built | You picked the wrong **Use workflow from** ref; re-run from the intended branch/tag. |

## 6) Recommended rollout approach

- Run from a **non-production branch/tag** first and use a clear **`release_name`** (for example including “test”).
- Confirm install, startup, and updater behavior against expectations.
- Promote usage from **`main`** or release tags once stable. Prereleases are created with `prerelease: true` in the wait workflow today; adjust that YAML if you want stable (non-prerelease) releases or change tagging.

## References

- [OSSign – Your OSSign Workflow (trigger workflow)](https://github.com/OSSign/template-repository/wiki/Your-OSSign-Workflow#the-trigger-workflow)
- [OSSign/example-workflow](https://github.com/ossign/example-workflow)
- [DesQTA build & deployment – Signed Windows binaries](build-deployment.md#signed-windows-binaries-ossign)
